### PR TITLE
Convert deprecated shape_tools dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_simple_grasps
   std_msgs
   geometry_msgs
+  geometric_shapes
   roscpp
   cmake_modules
   object_recognition_msgs
@@ -20,7 +21,7 @@ find_package(Boost QUIET COMPONENTS program_options)
 
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS
+  CATKIN_DEPENDS geometric_shapes
 )
 
 ###########

--- a/include/romeo_moveit_actions/metablock.hpp
+++ b/include/romeo_moveit_actions/metablock.hpp
@@ -5,7 +5,7 @@
 #include <ros/ros.h>
 
 #include <geometry_msgs/Pose.h>
-#include <shape_tools/solid_primitive_dims.h>
+#include <geometric_shapes/solid_primitive_dims.h>
 
 #include <object_recognition_msgs/RecognizedObjectArray.h>
 

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <build_depend>moveit_simple_grasps</build_depend>
   <build_depend>moveit_visual_tools</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>geometric_shapes</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>std_msgs</build_depend>
@@ -32,6 +33,7 @@
   <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_simple_grasps</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>geometric_shapes</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>object_recognition_msgs</run_depend>

--- a/src/metablock.cpp
+++ b/src/metablock.cpp
@@ -41,7 +41,7 @@ MetaBlock::MetaBlock(const std::string name,
   {
     shape_msgs::SolidPrimitive shapeCylinder;
     shapeCylinder.type = shape_msgs::SolidPrimitive::CYLINDER;
-    shapeCylinder.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value);
+    shapeCylinder.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value);
     shapeCylinder.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT] = size*size_r;
     shapeCylinder.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] = size;
     this->shape = shapeCylinder;
@@ -50,7 +50,7 @@ MetaBlock::MetaBlock(const std::string name,
   {
     shape_msgs::SolidPrimitive shapeBox;
     shapeBox.type = shape_msgs::SolidPrimitive::BOX;
-    shapeBox.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
+    shapeBox.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
     shapeBox.dimensions[shape_msgs::SolidPrimitive::BOX_X] = size;
     shapeBox.dimensions[shape_msgs::SolidPrimitive::BOX_Y] = size;
     shapeBox.dimensions[shape_msgs::SolidPrimitive::BOX_Z] = size;
@@ -88,7 +88,7 @@ MetaBlock::MetaBlock(const std::string name,
   {
     shape_msgs::SolidPrimitive shapeCylinder;
     shapeCylinder.type = shape_msgs::SolidPrimitive::CYLINDER;
-    shapeCylinder.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value);
+    shapeCylinder.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value);
     shapeCylinder.dimensions[shape_msgs::SolidPrimitive::CYLINDER_HEIGHT] = size_l;
     shapeCylinder.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] = size;
     this->shape = shapeCylinder;
@@ -97,7 +97,7 @@ MetaBlock::MetaBlock(const std::string name,
   {
     shape_msgs::SolidPrimitive shapeBox;
     shapeBox.type = shape_msgs::SolidPrimitive::BOX;
-    shapeBox.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
+    shapeBox.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::BOX>::value);
     shapeBox.dimensions[shape_msgs::SolidPrimitive::BOX_X] = size;
     shapeBox.dimensions[shape_msgs::SolidPrimitive::BOX_Y] = size;
     shapeBox.dimensions[shape_msgs::SolidPrimitive::BOX_Z] = size_l;

--- a/src/simplepickplace.cpp
+++ b/src/simplepickplace.cpp
@@ -994,7 +994,7 @@ ROS_INFO_STREAM("action_left->grasp_data_.base_link_ = " << action_left->grasp_d
     {
       shape_msgs::SolidPrimitive msg_cylinder_;
       msg_cylinder_.type = shape_msgs::SolidPrimitive::CYLINDER;
-      msg_cylinder_.dimensions.resize(shape_tools::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value);
+      msg_cylinder_.dimensions.resize(geometric_shapes::SolidPrimitiveDimCount<shape_msgs::SolidPrimitive::CYLINDER>::value);
       msg_cylinder_.dimensions[shape_msgs::SolidPrimitive::CYLINDER_RADIUS] = block_size;
       msg_cylinder_.dimensions[shape_msgs::SolidPrimitive::CONE_HEIGHT] = block_size_l;
 


### PR DESCRIPTION
`shape_tools` functionality was merged into `geometric_shapes`:
https://github.com/ros-planning/geometric_shapes/pull/32
and removed from `moveit_core`
https://github.com/ros-planning/moveit_core/pull/242
the deprecation of which causes a failed build from a clean ROS environment.

This commit updates the pick and place tutorial and adds
`geometric_shapes` to the `package.xml` and `CMakeLists.txt` to
prevent the ROS buildfarm from failing to build this package:
http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__romeo_moveit_actions__ubuntu_trusty_amd64__binary/9/console

After this merge, please cut a new release and bloom `romeo_moveit_actions` up to rosdistro. Thanks!
